### PR TITLE
Parse proxy port, and pass into HttpHost separately

### DIFF
--- a/src/main/java/com/notronix/newrelic/events/NewRelicClient.java
+++ b/src/main/java/com/notronix/newrelic/events/NewRelicClient.java
@@ -140,8 +140,14 @@ public class NewRelicClient
         if (!proxies.isEmpty())
         {
             Proxy proxy = proxies.get(0);
-            HttpHost proxyHost = new HttpHost(proxy.address().toString());
-            defaultRequestConfigBuilder.setProxy(proxyHost);
+            String[] fields = proxy.address().toString().split(":");
+            String host = fields[0];
+            int port = -1;
+            if (fields.length > 1)
+            {
+                port = Integer.parseInt(fields[1]);
+            }
+            defaultRequestConfigBuilder.setProxy(new HttpHost(host, port));
         }
         RequestConfig defaultRequestConfig = defaultRequestConfigBuilder.build();
 


### PR DESCRIPTION
@cmunden @clint-munden-vgh  HttpHost object was using the port number as part of the host name, and setting actual port number to -1. This change will parse the port number out separately and if it exists, pass it into the HttpHost constructor.