### PR TITLE
Handle no proxy correctly

### DIFF
--- a/src/main/java/com/notronix/newrelic/events/NewRelicClient.java
+++ b/src/main/java/com/notronix/newrelic/events/NewRelicClient.java
@@ -140,14 +140,16 @@ public class NewRelicClient
         if (!proxies.isEmpty())
         {
             Proxy proxy = proxies.get(0);
-            String[] fields = proxy.address().toString().split(":");
-            String host = fields[0];
-            int port = -1;
-            if (fields.length > 1)
+            if (Proxy.Type.HTTP.equals(proxy.type()))
             {
-                port = Integer.parseInt(fields[1]);
+                String[] fields = proxy.address().toString().split(":");
+                String host = fields[0];
+                int port = -1;
+                if (fields.length > 1) {
+                    port = Integer.parseInt(fields[1]);
+                }
+                defaultRequestConfigBuilder.setProxy(new HttpHost(host, port));
             }
-            defaultRequestConfigBuilder.setProxy(new HttpHost(host, port));
         }
         RequestConfig defaultRequestConfig = defaultRequestConfigBuilder.build();
 


### PR DESCRIPTION
If there is no proxy set up a DIRECT proxy will be returned by the
ProxySelector. Only set up proxy if it's an HTTP proxy.
